### PR TITLE
Create Signup & update Signin & Rename usersInfo

### DIFF
--- a/back/auth/index.js
+++ b/back/auth/index.js
@@ -1,16 +1,16 @@
 const jwt = require('jsonwebtoken');
-const userDatabase = require('../user');
+const usersInfo = require('../user');
 
 /* --------------------------------- handler -------------------------------- */
 // 로그인 검증이 필요한 페이지에서 서버로 요청이 들어올 때 유저의 브라우저에서 토큰을 확인하고 해당 토큰이 유효하면 유저 정보를 반환하는 함수.
-const getUserData = (req, res) => {
+const getUserInfo = (req, res) => {
   try {
     const token = req.cookies.accessToken;
     const decode = jwt.verify(token, process.env.ACCESS_SECRET);
 
-    const userData = userDatabase.find(user => user.email === decode.email && user.password === decode.password);
+    const userInfo = usersInfo.find(user => user.email === decode.email && user.password === decode.password);
 
-    return userData;
+    return userInfo;
   } catch {
     // 토큰이 유효하지 않다면 유저 정보를 반환하는 대신 500 에러를 띄운다.
     // NOTE: 클라이언트에서 서버에 요청했을 때 500 에러를 전달받는다면(res.status===500) 동작을 중지시키고 Signin 페이지로 강제로 이동시킨다.
@@ -18,4 +18,4 @@ const getUserData = (req, res) => {
   }
 };
 
-module.exports = { getUserData };
+module.exports = { getUserInfo };

--- a/back/routes/game.js
+++ b/back/routes/game.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { getUserData } = require('../auth');
+const { getUserInfo } = require('../auth');
 
 const router = express.Router();
 
@@ -8,7 +8,7 @@ router.use((req, res, next) => {
 });
 
 router.get('/', (req, res) => {
-  const { voca } = getUserData(req, res);
+  const { voca } = getUserInfo(req, res);
   let allVocaWords = [];
 
   voca.forEach(({ words }) => {

--- a/back/routes/signin.js
+++ b/back/routes/signin.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const jwt = require('jsonwebtoken');
-const userDatabase = require('../user');
+const usersInfo = require('../user');
 
 const router = express.Router();
 
@@ -14,7 +14,7 @@ router.post('/', (req, res) => {
   const { email, password } = req.body;
 
   // 전달받은 email/password로 데이터 베이스를 필터링해서 유저가 데이터베이스에 있는지 확인
-  const userInfo = userDatabase.find(user => user.email === email && user.password === password);
+  const userInfo = usersInfo.find(user => user.email === email && user.password === password);
 
   if (!userInfo) {
     // 유저가 데이터베이스에 없으면 에러 처리

--- a/back/routes/signup.js
+++ b/back/routes/signup.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const usersInfo = require('../user');
 
 const router = express.Router();
 
@@ -6,8 +7,28 @@ router.use((req, res, next) => {
   next();
 });
 
-router.get('/', () => {});
+const generateNextId = () => Math.max(0, ...usersInfo.map(({ userId }) => +userId)) + 1;
 
-router.post('/', () => {});
+router.post('/', (req, res) => {
+  const { email, userName, password } = req.body;
+
+  const userInfo = usersInfo.find(user => user.email === email);
+
+  // userInfo가 있으면 이미 가입된 회원이라는 에러를 띄워줌
+  if (userInfo) {
+    res.status(409).json('Signup comflict!');
+  } else {
+    usersInfo.push({
+      userId: generateNextId(),
+      email,
+      name: userName,
+      password,
+      voca: [],
+      wordsCount: 0,
+    });
+    res.status(201).json('Signup success!');
+    console.log('[newUser]', usersInfo.at(-1));
+  }
+});
 
 module.exports = router;

--- a/back/routes/vocalist.js
+++ b/back/routes/vocalist.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { getUserData } = require('../auth');
+const { getUserInfo } = require('../auth');
 
 const router = express.Router();
 
@@ -8,7 +8,7 @@ router.use((req, res, next) => {
 });
 
 router.get('/', (req, res) => {
-  const { name, voca, wordsCount } = getUserData(req, res);
+  const { name, voca, wordsCount } = getUserInfo(req, res);
   const infoToSend = { name, voca, wordsCount };
 
   res.send(infoToSend);

--- a/back/routes/wordlist.js
+++ b/back/routes/wordlist.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { getUserData } = require('../auth');
+const { getUserInfo } = require('../auth');
 
 const router = express.Router();
 
@@ -8,7 +8,7 @@ router.use((req, res, next) => {
 });
 
 router.get('/', (req, res) => {
-  const { voca } = getUserData(req, res);
+  const { voca } = getUserInfo(req, res);
 
   res.send(voca);
 });

--- a/front/src/component/SignIn.js
+++ b/front/src/component/SignIn.js
@@ -10,9 +10,9 @@ import {
   changeSignPage,
 } from '../css/Sign.module.css';
 import Component from '../core/Component';
+import { signinSchema } from '../validation/schema';
 
 class SignIn extends Component {
-  // TODO: js 적용 렌더링
   // eslint-disable-next-line class-methods-use-this
   render() {
     return `
@@ -29,7 +29,7 @@ class SignIn extends Component {
               autofocus 
               required 
             />
-            <p class="${error} ${hide}">올바른 이메일 형식이 아닙니다.</p>
+            <p class="${error} ${hide}">${signinSchema.email.error}</p>
           </li>
           <li class="${signItem}">
             <label for="password" class="${label}">Password</label>
@@ -40,7 +40,7 @@ class SignIn extends Component {
               class="${input}" 
               required 
             />
-            <p class="${error} ${hide}">6자리 이상의 문자를 입력해주세요.</p>
+            <p class="${error} ${hide}">${signinSchema.password.error}</p>
           </li>
         </ul>
         <button type="submit" class="${submitButton} ${fillButton}" disabled>ENTER</button>
@@ -50,11 +50,11 @@ class SignIn extends Component {
   }
 
   addEventListener() {
-    const { valid, checkUser, routeSignUpPage } = this.props;
+    const { valid, postSignIn, changePath } = this.props;
     return [
       { type: 'input', selector: `.${input}`, handler: valid },
-      { type: 'click', selector: `.${changeSignPage}`, handler: routeSignUpPage },
-      { type: 'click', selector: `.${submitButton}`, handler: checkUser },
+      { type: 'click', selector: `.${changeSignPage}`, handler: changePath },
+      { type: 'click', selector: `.${submitButton}`, handler: postSignIn },
     ];
   }
 }

--- a/front/src/component/SignUp.js
+++ b/front/src/component/SignUp.js
@@ -1,4 +1,4 @@
-import { title } from '../css/common.module.css';
+import { title, hide, fillButton, outlineButton } from '../css/common.module.css';
 import {
   signform,
   signList,
@@ -6,16 +6,14 @@ import {
   label,
   input,
   error,
-  hide,
   submitButton,
-  fillButton,
   changeSignPage,
-  outlineButton,
 } from '../css/Sign.module.css';
 import Component from '../core/Component';
+import { signupSchema } from '../validation/schema';
 
 class SignUp extends Component {
-  // TODO: js 적용 렌더링
+  // eslint-disable-next-line class-methods-use-this
   render() {
     return `
       <h2 class="${title}">회원가입</h2>
@@ -31,18 +29,18 @@ class SignUp extends Component {
               autofocus 
               required 
             />
-            <p class="${error} ${hide}">올바른 이메일 형식이 아닙니다.</p>
+            <p class="${error} ${hide}">${signupSchema.email.error}</p>
           </li>
           <li class="${signItem}">
-            <label for="username" class="${label}">User name</label>
+            <label for="userName" class="${label}">User name</label>
             <input
               type="text"
-              id="username"
-              name="username"
+              id="userName"
+              name="userName"
               class="${input}"
               required
             />
-            <p class="${error} ${hide}">1자리 이상의 문자를 입력해주세요.</p>
+            <p class="${error} ${hide}">${signupSchema.userName.error}</p>
           </li>
           <li class="${signItem}">
             <label for="password" class="${label}">Password</label>
@@ -53,7 +51,7 @@ class SignUp extends Component {
               class="${input}" 
               required 
             />
-            <p class="${error} ${hide}">6자리 이상의 문자를 입력해주세요.</p>
+            <p class="${error} ${hide}">${signupSchema.password.error}</p>
           </li>
           <li class="${signItem}">
             <label for="confirmPassword" class="${label}">Confirm pssword</label>
@@ -64,16 +62,23 @@ class SignUp extends Component {
               class="${input}"
               required
             />
-            <p class="${error} ${hide}">비밀번호가 일치하지 않습니다.</p>
+            <p class="${error} ${hide}">${signupSchema.confirmPassword.error}</p>
           </li>
         </ul>
-        <button type="submit" class="${submitButton} ${fillButton}">ENTER</button>
+        <button type="submit" class="${submitButton} ${fillButton}" disabled>ENTER</button>
       </form> 
       <a href="/signin" class="${changeSignPage} signup ${outlineButton}">로그인</a>
     `;
   }
 
-  // TODO: addEventHandler() {}
+  addEventListener() {
+    const { valid, postSignUp, changePath } = this.props;
+    return [
+      { type: 'input', selector: `.${input}`, handler: valid },
+      { type: 'click', selector: `.${changeSignPage}`, handler: changePath },
+      { type: 'click', selector: `.${submitButton}`, handler: postSignUp },
+    ];
+  }
 }
 
-export default SignUp;
+export { SignUp, hide, submitButton };

--- a/front/src/page/SignInPage.js
+++ b/front/src/page/SignInPage.js
@@ -14,14 +14,20 @@ class SignInPage extends Component {
 
   render() {
     return `${new SignIn({
-      valid: _.debounce(this.valid.bind(this)),
-      checkUser: this.checkUser.bind(this),
-      // routeSignUpPage: () => this.changePath.bind(this),
-      routeSignUpPage: this.routeSignUpPage.bind(this),
+      valid: _.debounce(this.valid.bind(this), 200),
+      postSignIn: this.postSignIn.bind(this),
+      changePath: () => this.changePath('/signup'),
     }).render()}`;
   }
 
-  /** input 이벤트 발생시 유효성 검사를 진행할 함수 구현 */
+  // eslint-disable-next-line class-methods-use-this
+  toggleSubmitButton() {
+    document.querySelector(`.${submitButton}`).disabled = !signinSchema.valid;
+  }
+
+  /* ------------------------------ Event Handler ----------------------------- */
+
+  /** input 이벤트 발생시 유효성 검사를 진행 */
   // eslint-disable-next-line class-methods-use-this
   valid(e) {
     signinSchema[e.target.name].value = e.target.value;
@@ -29,31 +35,26 @@ class SignInPage extends Component {
       ? e.target.nextElementSibling.classList.add(hide)
       : e.target.nextElementSibling.classList.remove(hide);
 
-    document.querySelector(`.${submitButton}`).disabled = !signinSchema.valid;
+    this.toggleSubmitButton();
   }
 
   /**
    * - submit 이벤트 발생시 서버에 user인지 확인 요청 보내고
    * - user면 VocaListPage('/')로 라우팅
    * - user가 아니면 toaster 메세지 띄우기
-   * TODO: checkUser라는 네이밍이 괜찮은지 코드 리뷰
+   * TODO: postSignIn라는 네이밍이 괜찮은지 코드 리뷰
    */
-  async checkUser(e) {
-    e.preventDefault();
+  async postSignIn() {
     const email = document.querySelector('input[name="email"]').value;
     const password = document.querySelector('input[name="password"]').value;
 
-    const isUser = await axios.post(`/api${this.props.path}`, { email, password });
-    // TODO: 회원이 아니면 회원이 아니라고 toaster 띄우기
-    // isUser ? this.changePath('/') : console.log('[Toaster] 가입된 정보가 없습니다');
-    isUser ? console.log('[Toaster] 로그인 성공') : console.log('[Toaster] 가입된 정보가 없습니다');
-  }
-
-  /** changeSignPage 클릭 이벤트시 회원가입으로 라우팅 */
-  // TODO: 라우트 구현시, a태그 클릭하면 href값을 인수로 전달하도록 만들기. -> changePath 함수에서 처음부터 공통으로 만드는게 좋을듯
-  // TODO: routeSignUpPage 메서드가 하는 일은 App의 chagnePath를 호출하며 인수를 전달하는 것 밖에 없다. 그렇다면 routeSignUpPage 메서드 없이 changePath를 사용하는게 좋지 않을까?
-  routeSignUpPage() {
-    this.changePath('/signup');
+    try {
+      await axios.post(`/api${this.props.path}`, { email, password });
+      console.log('[Toaster] 로그인 성공');
+      // TODO: this.changePath('/');
+    } catch (error) {
+      console.log('[Toaster] 가입된 정보가 없습니다');
+    }
   }
 }
 

--- a/front/src/page/SignUpPage.js
+++ b/front/src/page/SignUpPage.js
@@ -1,3 +1,72 @@
-class SignUpPage {}
+/* eslint-disable import/no-extraneous-dependencies */
+import axios from 'axios';
+import _ from 'lodash';
+import Component from '../core/Component';
+import { SignUp, hide, submitButton } from '../component/SignUp';
+import { signupSchema } from '../validation/schema';
+
+class SignUpPage extends Component {
+  constructor(props) {
+    super(props);
+
+    this.changePath = this.props.changePath;
+  }
+
+  render() {
+    return `${new SignUp({
+      valid: _.debounce(this.valid.bind(this), 200),
+      postSignUp: this.postSignUp.bind(this),
+      changePath: () => this.changePath('/signin'),
+    }).render()}`;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  toggleSubmitButton() {
+    document.querySelector(`.${submitButton}`).disabled = !signupSchema.valid;
+  }
+
+  /* ------------------------------ Event Handler ----------------------------- */
+
+  /** input 이벤트 발생시 유효성 검사를 진행 */
+  // eslint-disable-next-line class-methods-use-this
+  valid(e) {
+    signupSchema[e.target.name].value = e.target.value;
+    signupSchema[e.target.name].dirty = true;
+
+    e.target.nextElementSibling.classList.toggle(hide, signupSchema[e.target.name].valid);
+
+    if (e.target.name === 'password' && signupSchema.confirmPassword.dirty) {
+      document
+        .querySelector('input[name="confirmPassword"]')
+        .nextElementSibling.classList.toggle(hide, signupSchema.confirmPassword.valid);
+    }
+
+    this.toggleSubmitButton();
+  }
+
+  /**
+   * submit 이벤트 발생시 서버에서 이미 회원가입된 유저인지 확인
+   * - 중복된 이메일이면 fail toaster 띄우기
+   * - 새로운 회원이면 success toaster 띄우기
+   * TODO: postSignUp이라는 네이밍이 괜찮은지 코드 리뷰
+   */
+  async postSignUp() {
+    const email = signupSchema.email.value;
+    const userName = signupSchema.userName.value;
+    const password = signupSchema.password.value;
+
+    try {
+      // prettier-ignore
+      await axios.post(
+        `/api${this.props.path}`, 
+        { email, userName, password }
+      );
+      console.log(`[Toaster] ${userName}님의 회원가입이 완료되었습니다!`);
+      // TODO: this.changePath('/signin');
+    } catch (error) {
+      console.log('[Toaster] 이미 가입된 회원입니다');
+    }
+  }
+}
 
 export default SignUpPage;

--- a/front/src/page/page.js
+++ b/front/src/page/page.js
@@ -11,14 +11,14 @@ class Page extends Component {
     super();
 
     /**
-     * 페이지가 호출되면 서버에서 userInfo 데이터를 요청한다.
+     * 페이지가 호출되면 서버에서 usersInfo 데이터를 요청한다.
      * state에 전달받은 데이터를 저장한 뒤 Promise 객체에 this를 담아 반환한다.
      */
     // eslint-disable-next-line no-constructor-return
     return (async () => {
       try {
-        const { data: userInfo } = await axios.get('/user');
-        this.state = { userInfo };
+        const { data: usersInfo } = await axios.get('/user');
+        this.state = { usersInfo };
         return this;
       } catch (e) {
         console.error(e);

--- a/front/src/validation/schema.js
+++ b/front/src/validation/schema.js
@@ -4,9 +4,10 @@ const signinSchema = {
     error: '올바른 이메일 형식이 아닙니다.',
     dirty: false,
     get valid() {
+      // FIXME: TLD(Top Level Domain) 길이를 최대 3으로 고정해놨는데, 길이 체크를 안해줌.
       // prettier-ignore
       // eslint-disable-next-line max-len
-      return /^[0-9|a-z|A-Z]([-_.]?[0-9|a-z|A-Z])*@[0-9|a-z|A-Z]([-_.]?[0-9|a-z|A-Z])*.[a-z|A-Z]{2,3}/.test(this.value);
+      return /^[0-9|a-z|A-Z]([-_.]?[0-9|a-z|A-Z])*@[0-9|a-z|A-Z]([-_.]?[0-9|a-z|A-Z])*.[a-z|A-Z]{2,3}$/.test(this.value);
     },
   },
   password: {


### PR DESCRIPTION
SignUp 컴포넌트 및 SignUpPage 구현
close #79 

SignIn 로직 수정
- 페이지 라우팅시 routeSignUpPage 메서드 대신 props 받은 changePath를 직접 호출할 수 있도록 로직 변경
- checkUser 메서드 이름을 postSignIn으로 바꾸고 서버에서 받은 응답코드를 판단하여 로그인 로직을 실행할 수 있도록 변경

서버에서 userInfo 관련된 변수 이름 변경
- usersData -> usersInfo
- userData -> userInfo
- getUserData -> getUserInfo