### PR TITLE
Create getUserInfo function in server & Create WordListPage in progress

### DIFF
--- a/back/user.js
+++ b/back/user.js
@@ -26,7 +26,7 @@ const usersInfo = [
           { wordId: '1670999121000', word: 'eight', wordDescription: '8' },
           { wordId: '1670999131000', word: 'nine', wordDescription: '9' },
           { wordId: '1670999141000', word: 'ten', wordDescription: '10' },
-          { wordId: '1670999151000', word: 'eleven', wordDescription: '11' },
+          { wordId: '167099915100b', word: 'eleven', wordDescription: '11' },
         ],
       },
       {
@@ -38,6 +38,12 @@ const usersInfo = [
           { wordId: '1671299191000', word: 'mother', wordDescription: '어머니' },
           { wordId: '1671399191000', word: 'father', wordDescription: '아버지' },
         ],
+      },
+      {
+        vocaId: '1670999353333',
+        title: '',
+        vocaDescription: '',
+        words: [],
       },
     ],
   },

--- a/front/src/component/SignIn.js
+++ b/front/src/component/SignIn.js
@@ -53,7 +53,7 @@ class SignIn extends Component {
     const { valid, postSignIn, changePath } = this.props;
     return [
       { type: 'input', selector: `.signin .${input}`, handler: valid },
-      { type: 'click', selector: `.goToSignUp`, handler: e => changePath(e.target.pathname) },
+      { type: 'click', selector: `.${changeSignPage}`, handler: e => changePath(e.target.pathname) },
       { type: 'click', selector: `.signin .${submitButton}`, handler: postSignIn },
     ];
   }

--- a/front/src/component/SignUp.js
+++ b/front/src/component/SignUp.js
@@ -75,7 +75,7 @@ class SignUp extends Component {
     const { valid, postSignUp, changePath } = this.props;
     return [
       { type: 'input', selector: `.signup .${input}`, handler: valid },
-      { type: 'click', selector: `.goToSignIn`, handler: e => changePath(e.target.pathname) },
+      { type: 'click', selector: `.${changeSignPage}`, handler: e => changePath(e.target.pathname) },
       { type: 'click', selector: `.signup .${submitButton}`, handler: postSignUp },
     ];
   }

--- a/front/src/component/WordItem.js
+++ b/front/src/component/WordItem.js
@@ -1,3 +1,37 @@
-class WordItem {}
+import { wordItem, input, wordInput, removeIcon } from '../css/WordList.module.css';
+import Component from '../core/Component';
+
+class WordItem extends Component {
+  render() {
+    const { wordId, word, wordDescription } = this.props;
+
+    return `
+      <li class="${wordItem}" data-id="${wordId}">
+        <input
+          type="text"
+          name="word"
+          class="${input} ${wordInput}"
+          placeholder="단어 입력"
+          value="${word ?? ''}"
+        />
+        <input
+          type="text"
+          name="wordDescription"
+          class="${input} wordDescriptionInput"
+          placeholder="뜻 입력"
+          value="${wordDescription ?? ''}"
+        />
+        <button type="button" class="removeWord">
+          <i class="bx bx-x ${removeIcon}"></i>
+        </button>
+      </li>
+    `;
+  }
+
+  addEventListener() {
+    const { removeWordList } = this.props;
+    return [{ type: 'click', selector: `.removeWord`, handler: removeWordList }];
+  }
+}
 
 export default WordItem;

--- a/front/src/component/WordList.js
+++ b/front/src/component/WordList.js
@@ -1,9 +1,14 @@
 import { title, description, outlineButton } from '../css/common.module.css';
-import { input, buttonWrapper, addWord, addIcon } from '../css/WordList.module.css';
+import { input, wordList, buttonWrapper, addWord, addIcon } from '../css/WordList.module.css';
+import Component from '../core/Component';
 import WordItem from './WordItem';
 
-class WordList {
+class WordList extends Component {
   render() {
+    const vocaTitle = this.props.title;
+    const { vocaDescription, words, removeWordList } = this.props;
+
+    // prettier-ignore
     return `
       <header>
         <h2>
@@ -12,27 +17,32 @@ class WordList {
             name="title"
             class="${input} ${title}"
             placeholder="단어장 제목 입력"
+            value="${vocaTitle ?? ''}"
           />
         </h2>
         <input
           type="text"
           name="description"
           class="${input} ${description}"
-          placeholder="단어장에 대한 설명 입력"
+          placeholder="단어장 설명 입력"
+          value="${vocaDescription ?? ''}"
         />
       </header>
 
       <div class="content">
         <div class="${buttonWrapper}">
-          <button type="button" class="${outlineButton} active full">전체</button>
+          <button type="button" class="${outlineButton} full active">전체</button>
           <button type="button" class="${outlineButton} wordOnly">단어만</button>
           <button type="button" class="${outlineButton} descriptionOnly">
             뜻만
           </button>
         </div>
 
-        <ul class="wordList">
-          ${new WordItem().render()}
+        <ul class="${wordList}">
+          ${words.map(word => new WordItem({
+              ...word, 
+              removeWordList
+            }).render()).join('')}
         </ul>
 
         <button class="${addWord}">
@@ -40,6 +50,14 @@ class WordList {
         </button>
       </div>
     `;
+  }
+
+  addEventListener() {
+    const { patchWordList, addWordList } = this.props;
+    return [
+      { type: 'input', selector: `.${input}`, handler: patchWordList },
+      { type: 'click', selector: `.${addWord}`, handler: addWordList },
+    ];
   }
 }
 

--- a/front/src/css/WordList.module.css
+++ b/front/src/css/WordList.module.css
@@ -4,6 +4,12 @@
   padding: var(--size8) var(--size32);
 }
 
+.wordList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size12);
+}
+
 .buttonWrapper {
   display: flex;
   align-items: center;
@@ -18,8 +24,19 @@
   border: 3px solid var(--black);
 }
 
-.word {
+.wordInput {
+  flex-shrink: 0;
   width: 16rem;
+}
+
+.removeIcon {
+  display: none;
+  font-size: var(--size32);
+}
+
+.wordItem:hover .removeIcon {
+  display: block;
+  margin-right: var(--size20);
 }
 
 .addWord {

--- a/front/src/css/base.css
+++ b/front/src/css/base.css
@@ -13,9 +13,14 @@
   --size32: 1.6rem;
   --size20: 1rem;
   --size12: 0.6rem;
+  --size8: 0.4rem;
 }
 
 /* reset */
+h2 {
+  margin: 0;
+}
+
 ul {
   list-style: none;
   padding: 0;

--- a/front/src/page/WordListPage.js
+++ b/front/src/page/WordListPage.js
@@ -1,10 +1,13 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import axios from 'axios';
+import _ from 'lodash';
 import Component from '../core/Component';
 import WordList from '../component/WordList';
 
 class WordListPage extends Component {
   state = {};
+
+  vocaItem = {};
 
   constructor(props) {
     super(props);
@@ -16,9 +19,12 @@ class WordListPage extends Component {
     // eslint-disable-next-line no-constructor-return
     return (async () => {
       try {
-        const { data: vocaItemInfo } = await axios.get(`/api/wordlist/${this.props.vocaId}`);
-        this.state = { ...vocaItemInfo };
-        console.log(this.state);
+        /** @type {data: {title: String, vocaDescription: String, vocaId: String, words: Array<{wordId: String, word: String, wordDescription: String}>}}  */
+        const { data } = await axios.get(`/api/wordlist/${this.props.vocaId}`);
+        this.vocaItem = data;
+
+        // TODO: vocaItem이 아무것도 안들어오면 changePath(Not Found)
+        this.vocaItem ? (this.state = { ...this.vocaItem }) : console.log('[404 Not Found]');
         return this;
       } catch (e) {
         console.error(e);
@@ -29,12 +35,52 @@ class WordListPage extends Component {
   render() {
     const wordList = new WordList({
       ...this.state,
+      patchWordList: _.debounce(this.patchWordList.bind(this), 200),
+      addWordList: this.addWordList.bind(this),
+      removeWordList: this.removeWordList.bind(this),
     }).render();
 
     return `${wordList}`;
   }
 
-  // 하위 컴포넌트의 state를 변경하는 메서드들 등록
+  #changeWords(name, value, wordId) {
+    return this.state.words.map(word => (word.wordId === wordId ? { ...word, [name]: value } : { ...word }));
+  }
+
+  // TODO: wordList랑 wordItem이 따로 놈...
+  // eslint-disable-next-line class-methods-use-this
+  patchWordList(e) {
+    const { name, value } = e.target;
+    const wordId = e.target.closest('li')?.dataset.id;
+    const newVocaItem = wordId
+      ? { ...this.vocaItem, words: this.#changeWords(name, value, wordId) }
+      : { ...this.vocaItem, [name]: value };
+
+    axios.patch(`/api/wordlist/${this.state.vocaId}`, newVocaItem);
+    this.setState(newVocaItem);
+  }
+
+  // WordList의 + 버튼 클릭 이벤트 발생시 서버에 words 배열에 새로운 word 추가: {wordId: string(날짜), word: '', wordDescription: ''}
+  addWordList() {
+    // eslint-disable-next-line no-undef
+    const wordId = Date.now() + '';
+    const newVocaItem = { ...this.state, words: [...this.state.words, { wordId, word: '', wordDescription: '' }] };
+
+    axios.patch(`/api/wordlist/${this.state.vocaId}`, newVocaItem);
+    this.setState(newVocaItem);
+  }
+
+  // WordItem의 x 버튼 클릭시 서버에서 삭제
+  removeWordList(e) {
+    // eslint-disable-next-line no-undef
+    const wordId = e.target.closest('li').dataset.id;
+    const newVocaItem = { ...this.state, words: this.state.words.filter(word => word.wordId !== wordId) };
+
+    axios.patch(`/api/wordlist/${this.state.vocaId}`, newVocaItem);
+    this.setState(newVocaItem);
+  }
+
+  // 전체, 단어만, 뜻만 버튼 클릭시 WordList에 출력될 아이템 필터링
 }
 
 export default WordListPage;


### PR DESCRIPTION
- 서버에서 페이지 제약 없이 로그인한 회원 정보 받아올 수 있도록 로직 구현 close #123

WordListPage (진행중)
- 주소창 url이나 this.path의 path가 /wordlist/vocaId로 들어오면 WordListPage로 라우팅
- WordListPage를 호출할 때 props로 vocaId를 넘겨줘야 함
- 서버에서 vocaId에 해당하는 데이터를 전달받아서 this.state = {vocaId, title, vocaDescription, words} 를 저장함
- render 메서드에서 WordList 컴포넌트 호출하면서 this.state와 handler 함수 전달
- handler 함수 구현
- WordList의 title에 input 이벤트 발생시 서버에 업데이트 (lodash의 debounce 사용)
- WordList의 vocaDescription에 input 이벤트 발생시 서버에 업데이트 (lodash의 debounce 사용)
- WordList의 + 버튼 클릭 이벤트 발생시 서버에 words 배열에 새로운 word 추가: {wordId: string(날짜), word: '', wordDescription: ''}
- WordItem의 word에 Input 이벤트 발생시 서버에 업데이트 (lodash의 debounce 사용)
- WordItem의 wordDescription에 Input 이벤트 발생시 서버에 업데이트 (lodash의 debounce 사용)
- WordItem의 x 버튼 클릭시 서버에서 삭제